### PR TITLE
feat: allow getting more info from version command

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "husky": "6",
     "mocha": "^8.2.1",
     "oclif": "2.1.0",
+    "shx": "^0.3.4",
     "ts-node": "^10.4.0",
     "typescript": "4.6.3"
   },
@@ -46,9 +47,9 @@
   },
   "repository": "oclif/plugin-version",
   "scripts": {
-    "build": "rm -rf lib && tsc",
+    "build": "shx rm -rf lib && tsc",
     "commitlint": "commitlint",
-    "clean": "rm -f oclif.manifest.json",
+    "clean": "shx rm -f oclif.manifest.json",
     "lint": "eslint . --ext .ts --config .eslintrc",
     "pretest": "yarn build",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,5 +1,5 @@
 import {Command, Flags} from '@oclif/core'
-import {type as osType, release as osRelease} from 'node:os'
+import {EOL, type as osType, release as osRelease} from 'node:os'
 
 export default class Version extends Command {
   public static flags = {
@@ -11,7 +11,7 @@ export default class Version extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Version)
-    let output = `${this.config.userAgent} \n`
+    let output = `${this.config.userAgent}${EOL}`
 
     if (flags.verbose) {
       const versions = this.config.userAgent.split(' ')
@@ -19,21 +19,21 @@ export default class Version extends Command {
       const architecture: string = versions[1]
       const nodeVersion: string = versions[2]
 
-      const pluginVersions: string = this.config.plugins.reduce((accumulator, plugin) => {
-        accumulator += `\n\t${plugin.name}@${plugin.version} (${plugin.type})`
-        return accumulator
-      }, '')
+      let pluginVersions = ''
+      for (const plugin of this.config.plugins) {
+        pluginVersions += `${EOL}\t${plugin.name}@${plugin.version} (${plugin.type})`
+      }
 
       const osVersion = `${osType()} ${osRelease()}`
 
-      output = ` CLI Version : \n\t${cliVersion}
-\n Architecture: \n\t${architecture}
-\n Node Version : \n\t${nodeVersion}
-\n Plugin Version: ${pluginVersions}
-\n OS and Version: \n\t${osVersion}
+      output = ` CLI Version : ${EOL}\t${cliVersion}
+${EOL} Architecture: ${EOL}\t${architecture}
+${EOL} Node Version : ${EOL}\t${nodeVersion}
+${EOL} Plugin Version: ${pluginVersions}
+${EOL} OS and Version: ${EOL}\t${osVersion}
 `
     }
 
-    this.log(output)
+    process.stdout.write(output)
   }
 }

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,7 +1,39 @@
-import {Command} from '@oclif/core'
+import {Command, Flags} from '@oclif/core'
+import {type as osType, release as osRelease} from 'node:os'
 
 export default class Version extends Command {
+  public static flags = {
+    verbose: Flags.boolean({
+      summary: 'Show additional information about the CLI.',
+      description: 'Additionally shows the architecture, node version, operating system, and versions of plugins that the CLI is using.',
+    }),
+  }
+
   async run(): Promise<void> {
-    process.stdout.write(this.config.userAgent + '\n')
+    const {flags} = await this.parse(Version)
+    let output = `${this.config.userAgent} \n`
+
+    if (flags.verbose) {
+      const versions = this.config.userAgent.split(' ')
+      const cliVersion: string = versions[0]
+      const architecture: string = versions[1]
+      const nodeVersion: string = versions[2]
+
+      const pluginVersions: string = this.config.plugins.reduce((accumulator, plugin) => {
+        accumulator += `\n\t${plugin.name}@${plugin.version} (${plugin.type})`
+        return accumulator
+      }, '')
+
+      const osVersion = `${osType()} ${osRelease()}`
+
+      output = ` CLI Version : \n\t${cliVersion}
+\n Architecture: \n\t${architecture}
+\n Node Version : \n\t${nodeVersion}
+\n Plugin Version: ${pluginVersions}
+\n OS and Version: \n\t${osVersion}
+`
+    }
+
+    this.log(output)
   }
 }

--- a/test/commands/version.test.ts
+++ b/test/commands/version.test.ts
@@ -1,10 +1,11 @@
 import {expect, test} from '@oclif/test'
+import {EOL} from 'node:os'
 
 // eslint-disable-next-line unicorn/prefer-module
 const pjson = require('../../package.json')
 
 describe('version', () => {
-  const stdout = `@oclif/plugin-version/${pjson.version} ${process.platform}-${process.arch} node-${process.version}\n`
+  const stdout = `@oclif/plugin-version/${pjson.version} ${process.platform}-${process.arch} node-${process.version}${EOL}`
 
   test
   .stdout()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,6 +3794,11 @@ minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minimist@^1.2.3:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -4873,6 +4878,23 @@ shelljs@^0.8.0, shelljs@^0.8.4:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shelljs@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
+shx@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
+  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
+  dependencies:
+    minimist "^1.2.3"
+    shelljs "^0.8.5"
 
 signal-exit@^3.0.0:
   version "3.0.6"


### PR DESCRIPTION
## What does this PR do?
Adds a `--verbose` flag to the `version` command that outputs more information about the CLI or plugin that it is run on.

Closes https://github.com/forcedotcom/cli/issues/1566