### PR TITLE
fix: avoid node:os protocol

### DIFF
--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,5 +1,6 @@
 import {Command, Flags} from '@oclif/core'
-import {EOL, type as osType, release as osRelease} from 'node:os'
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import {EOL, type as osType, release as osRelease} from 'os'
 
 export interface VersionDetail {
   cliVersion: string;


### PR DESCRIPTION
https://github.com/forcedotcom/cli/issues/1728

fyi: oclif's unicorn eslint is starting to propgate this everywhere.