### PR TITLE
fix: display current CLI version

### DIFF
--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -104,7 +104,7 @@ export default class Version extends Command {
 
       const cliPublishedString = details
         ? ansis.dim(
-            ` published ${daysAgo(details.time[details.version])} days ago (${humanReadableDate(details.time[details.version])})`,
+            ` published ${daysAgo(details.time[this.config.version])} days ago (${humanReadableDate(details.time[this.config.version])})`,
           )
         : ''
       const notLatestWarning =


### PR DESCRIPTION
npm always returns the latest version under `version` so we need to access the publish date using `this.config.version` so that it shows the publish date of the current CLI version instead of always showing latest