### PR TITLE
fix:  use execFile to bypass shell command resolution-W-23662030

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -2,6 +2,6 @@
   "productTag": "a1aB0000000ce2IIAQ",
   "defaultBuild": "offcore.tooling.59",
   "issueTypeLabels": {"enhancement": "USER STORY", "bug": "BUG P3"},
-  "hideWorkItemUrl": true,
+  "hideWorkItemUrl": "true",
   "statusWhenClosed": "CLOSED"
 }

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,6 +1,6 @@
 import {Command, Flags, Interfaces} from '@oclif/core'
 import {Ansis} from 'ansis'
-import {exec} from 'node:child_process'
+import {execFile} from 'node:child_process'
 import {EOL} from 'node:os'
 
 const ansis = new Ansis()
@@ -20,11 +20,17 @@ type NpmDetails = {
 
 async function getNpmDetails(pkg: string): Promise<false | NpmDetails> {
   return new Promise((resolve) => {
-    exec(`npm view ${pkg} --json`, (error, stdout) => {
+    // Use execFile instead of exec to avoid shell interpretation.
+    // exec invokes cmd.exe on Windows, which resolves commands from CWD before PATH.
+    execFile('npm', ['view', pkg, '--json'], (error, stdout) => {
       if (error) {
         resolve(false)
       } else {
-        resolve(JSON.parse(stdout) as NpmDetails)
+        try {
+          resolve(JSON.parse(stdout) as NpmDetails)
+        } catch {
+          resolve(false)
+        }
       }
     })
   })


### PR DESCRIPTION
  ## Summary
  - Replace `child_process.exec()` with `child_process.execFile()` when invoking npm
  - `execFile` does not spawn a shell, preventing unintended command resolution from the working directory on Windows

  ## Test plan
  - [x] Existing unit tests pass
  - [x] Verified `sf version --verbose` works correctly on Windows and macOS
  - [x] Verified npm registry lookup still returns version info for user-installed plugins


@W-23662030@